### PR TITLE
Encode binary URI params

### DIFF
--- a/src/erlasticsearch.erl
+++ b/src/erlasticsearch.erl
@@ -1201,7 +1201,7 @@ intersperse(Sep, [X | Xs]) ->
   [X, Sep | intersperse(Sep, Xs)].
 
 uri_encode(Term) when is_binary(Term) ->
-    binary_to_list(Term);
+  uri_encode(binary_to_list(Term));
 uri_encode(Term) when is_integer(Term) ->
   integer_to_list(Term);
 uri_encode(Term) when is_atom(Term) ->


### PR DESCRIPTION
When a parameter was specified as a binary it was not encoded and ids in ElasticSearch needs to be uri-encoded.
