### PR TITLE
Explicit branch tuple in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,9 +14,9 @@
 {deps_dir, ["deps"]}.
 {deps, [
 %    {'lager', ".*", {git, "https://github.com/basho/lager.git", {tag, "2.0.0"}}},
-    {'jsx', ".*", {git, "git://github.com/talentdeficit/jsx.git", "master"}},
+    {'jsx', ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}},
     {'thrift', ".*", {git, "https://github.com/dieswaytoofast/thrift.git", {tag, "0.9.3"}}},
-    {'proper', ".*", {git, "https://github.com/manopapad/proper.git", "master"}},
+    {'proper', ".*", {git, "https://github.com/manopapad/proper.git", {branch, "master"}}},
     {'poolboy', ".*", {git, "git://github.com/devinus/poolboy.git", {tag, "1.0.0"}}},
     {'reltool_util', ".*", {git, "https://github.com/okeuday/reltool_util.git", {branch, "master"}}}
        ]}.


### PR DESCRIPTION
Recent versions of rebar say versions confict when you have:

```
ERROR: Conflicting dependencies for proper: [{"From: ubic_lib",
                                              {".*",
                                               {git,
                                                "https://github.com/manopapad/proper.git",
                                                {branch,"master"}}}},
                                             {"From: erlasticsearch",
                                              {".*",
                                               {git,
                                                "https://github.com/manopapad/proper.git",
                                                "master"}}}]
```
