### PR TITLE
Download deps automatically if missing when compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PLT_APPS := $(shell ls $(ERL_LIB_DIR) | grep -v interface | sed -e 's/-[0-9.]*//
 
 all: compile
 
-compile:
+compile: deps
 	@rebar compile
 
 deps:


### PR DESCRIPTION
When running `make` dependencies are not automatically downloaded.

Usually this is not a problem since we can run `make deps compile`.

But if you use https://github.com/extend/erlang.mk you can not do this. Erlang.mk will automagically call `make` and that's it (ref : https://github.com/extend/erlang.mk/blob/master/erlang.mk#L184)

This pull request solves this problem.
