### PR TITLE
Bump poolboy version to 1.5.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
     {'jsx', ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}},
     {'thrift', ".*", {git, "https://github.com/dieswaytoofast/thrift.git", {tag, "0.9.3"}}},
     {'proper', ".*", {git, "https://github.com/manopapad/proper.git", {branch, "master"}}},
-    {'poolboy', ".*", {git, "git://github.com/devinus/poolboy.git", {tag, "1.0.0"}}},
+    {'poolboy', ".*", {git, "git://github.com/devinus/poolboy.git", {tag, "1.5.1"}}},
     {'reltool_util', ".*", {git, "https://github.com/okeuday/reltool_util.git", {branch, "master"}}}
        ]}.
 {cover_enabled, true}.


### PR DESCRIPTION
For R17 support.
Compiling poolboy v1.0.* on R17 fails with deprecation errors.

``` sh
==> poolboy (compile)
Compiling /Users/user/Project/erlibral/deps/poolboy/src/poolboy.erl failed:
/Users/user/Project/erlibral/deps/poolboy/src/poolboy.erl:16: type queue/0 is deprecated and will be removed in OTP 18.0; use use queue:queue/0 or preferably queue:queue/1
/Users/user/Project/erlibral/deps/poolboy/src/poolboy.erl:17: type queue/0 is deprecated and will be removed in OTP 18.0; use use queue:queue/0 or preferably queue:queue/1
ERROR: compile failed while processing /Users/user/Project/erlibral/deps/poolboy: rebar_abort
```